### PR TITLE
Add CLI

### DIFF
--- a/piquel-core/src/ipc/client.rs
+++ b/piquel-core/src/ipc/client.rs
@@ -8,13 +8,30 @@ use std::{
     usize,
 };
 
-pub trait IpcClient {
-    fn send_command(&mut self, command: &Command) -> io::Result<Response>;
-    fn get_type(&self) -> ConnectionType;
+trait ReadWrite: Write + Read {}
+impl<T: Write + Read> ReadWrite for T {}
+
+pub struct Client {
+    stream: Box<dyn ReadWrite>,
+    client_type: ConnectionType,
 }
 
-impl<T: Read + Write> IpcClient for Client<T> {
-    fn send_command(&mut self, command: &Command) -> io::Result<Response> {
+impl Client {
+    pub fn new_tcp(addr: &str) -> io::Result<Self> {
+        let stream = TcpStream::connect(addr)?;
+        Ok(Self {
+            stream: Box::new(stream),
+            client_type: ConnectionType::Tcp,
+        })
+    }
+    pub fn new_uds(path: &str) -> io::Result<Self> {
+        let stream = UnixStream::connect(path)?;
+        Ok(Self {
+            stream: Box::new(stream),
+            client_type: ConnectionType::Uds,
+        })
+    }
+    pub fn send_command(&mut self, command: &Command) -> io::Result<Response> {
         let request = serde_json::to_vec(&command)?;
         let len = (request.len() as u32).to_be_bytes();
         self.stream.write_all(&len)?;
@@ -30,38 +47,7 @@ impl<T: Read + Write> IpcClient for Client<T> {
         let response: Response = serde_json::from_slice(&response_buf)?;
         Ok(response)
     }
-    fn get_type(&self) -> ConnectionType {
+    pub fn get_type(&self) -> ConnectionType {
         self.client_type
-    }
-}
-
-pub struct Client<T: Read + Write> {
-    stream: T,
-    client_type: ConnectionType,
-}
-
-pub type TcpClient = Client<TcpStream>;
-
-impl TcpClient {
-    pub fn new(addr: &str) -> io::Result<Self> {
-        let stream = TcpStream::connect(addr)?;
-        println!("[client] Connected to {addr}");
-        Ok(Self {
-            stream,
-            client_type: ConnectionType::Tcp,
-        })
-    }
-}
-
-pub type UdsClient = Client<UnixStream>;
-
-impl UdsClient {
-    pub fn new(path: &str) -> io::Result<Self> {
-        let stream = UnixStream::connect(path)?;
-        println!("[client] Connected to {path}");
-        Ok(Self {
-            stream,
-            client_type: ConnectionType::Uds,
-        })
     }
 }

--- a/piquel-core/src/ipc/client.rs
+++ b/piquel-core/src/ipc/client.rs
@@ -8,16 +8,13 @@ use std::{
     usize,
 };
 
-pub struct Client<T: Read + Write> {
-    stream: T,
-    client_type: ConnectionType,
+pub trait IpcClient {
+    fn send_command(&mut self, command: &Command) -> io::Result<Response>;
+    fn get_type(&self) -> ConnectionType;
 }
 
-impl<T: Read + Write> Client<T> {
-    pub fn get_type(&self) -> ConnectionType {
-        self.client_type
-    }
-    pub fn send_command(&mut self, command: &Command) -> io::Result<Response> {
+impl<T: Read + Write> IpcClient for Client<T> {
+    fn send_command(&mut self, command: &Command) -> io::Result<Response> {
         let request = serde_json::to_vec(&command)?;
         let len = (request.len() as u32).to_be_bytes();
         self.stream.write_all(&len)?;
@@ -33,6 +30,14 @@ impl<T: Read + Write> Client<T> {
         let response: Response = serde_json::from_slice(&response_buf)?;
         Ok(response)
     }
+    fn get_type(&self) -> ConnectionType {
+        self.client_type
+    }
+}
+
+pub struct Client<T: Read + Write> {
+    stream: T,
+    client_type: ConnectionType,
 }
 
 pub type TcpClient = Client<TcpStream>;

--- a/piquel-core/src/ipc/client.rs
+++ b/piquel-core/src/ipc/client.rs
@@ -1,7 +1,4 @@
-use crate::{
-    config::{LISTEN_ADDR, SOCKET_PATH},
-    ipc::ConnectionType,
-};
+use crate::ipc::ConnectionType;
 
 use super::message::{Command, Response};
 use std::{
@@ -41,9 +38,9 @@ impl<T: Read + Write> Client<T> {
 pub type TcpClient = Client<TcpStream>;
 
 impl TcpClient {
-    pub fn new() -> io::Result<Self> {
-        let stream = TcpStream::connect(LISTEN_ADDR)?;
-        println!("[client] Connected to {LISTEN_ADDR}");
+    pub fn new(addr: &str) -> io::Result<Self> {
+        let stream = TcpStream::connect(addr)?;
+        println!("[client] Connected to {addr}");
         Ok(Self {
             stream,
             client_type: ConnectionType::Tcp,
@@ -54,9 +51,9 @@ impl TcpClient {
 pub type UdsClient = Client<UnixStream>;
 
 impl UdsClient {
-    pub fn new() -> io::Result<Self> {
-        let stream = UnixStream::connect(SOCKET_PATH)?;
-        println!("[client] Connected to {SOCKET_PATH}");
+    pub fn new(path: &str) -> io::Result<Self> {
+        let stream = UnixStream::connect(path)?;
+        println!("[client] Connected to {path}");
         Ok(Self {
             stream,
             client_type: ConnectionType::Uds,

--- a/piquel-core/src/ipc/message.rs
+++ b/piquel-core/src/ipc/message.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 pub enum Command {
     Echo(String),
     Status,
+    Hostname,
     Reload,
     Stop,
 }

--- a/piquel-core/src/ipc/server.rs
+++ b/piquel-core/src/ipc/server.rs
@@ -77,19 +77,22 @@ where
 }
 
 fn process_command(command: Command) -> io::Result<Response> {
-    match command {
-        Command::Stop => {
-            println!("Received stop command");
-            Ok(Response::Ok)
-        }
+    Ok(match command {
         Command::Status => {
             println!("Received status command");
-            Ok(Response::Ok)
+            Response::Ok
         }
+        Command::Hostname => {
+            Response::Message("TODO: implement getting hostname on server".to_string())
+        }
+        Command::Echo(msg) => Response::Message(msg),
         Command::Reload => {
             println!("Received reload command");
-            Ok(Response::Ok)
+            Response::Ok
         }
-        Command::Echo(msg) => Ok(Response::Message(msg)),
-    }
+        Command::Stop => {
+            println!("Received stop command");
+            Response::Ok
+        }
+    })
 }

--- a/piquel-core/src/ipc/server.rs
+++ b/piquel-core/src/ipc/server.rs
@@ -76,12 +76,10 @@ where
     }
 }
 
+// TODO: processing should be handled by server
 fn process_command(command: Command) -> io::Result<Response> {
     Ok(match command {
-        Command::Status => {
-            println!("Received status command");
-            Response::Ok
-        }
+        Command::Status => Response::Message("Status OK".to_string()),
         Command::Hostname => {
             // TODO: hostname
             Response::Message("waiting for std::net::hostname() to become available".to_string())

--- a/piquel-core/src/ipc/server.rs
+++ b/piquel-core/src/ipc/server.rs
@@ -83,7 +83,8 @@ fn process_command(command: Command) -> io::Result<Response> {
             Response::Ok
         }
         Command::Hostname => {
-            Response::Message("TODO: implement getting hostname on server".to_string())
+            // TODO: hostname
+            Response::Message("waiting for std::net::hostname() to become available".to_string())
         }
         Command::Echo(msg) => Response::Message(msg),
         Command::Reload => {

--- a/piquelctl/src/cli.rs
+++ b/piquelctl/src/cli.rs
@@ -5,12 +5,12 @@ pub fn parse() -> Cli {
     Cli::parse()
 }
 
-/// A CLI client for interacting with the daemon
+/// CLI client for interacting with piqueld
 #[derive(Parser, Debug)]
 #[command(name = "piquelctl")]
-#[command(about = "CLI client for the daemon", long_about = None)]
+#[command(about = "CLI for piqueld", long_about = None)]
 pub struct Cli {
-    /// Connect to a remote daemon over TCP (e.g. 127.0.0.1:9000)
+    /// Connect to a remote daemon over TCP (e.g. 127.0.0.1:7854)
     #[arg(short = 'H', long = "host", value_name = "HOST", global = true)]
     pub host: Option<String>,
 
@@ -32,7 +32,6 @@ pub struct Cli {
 pub enum Commands {
     /// Returns the hostname of the daemon
     Hostname,
-    Echo {
-        message: String,
-    },
+    /// Just echoes the message
+    Echo { message: String },
 }

--- a/piquelctl/src/cli.rs
+++ b/piquelctl/src/cli.rs
@@ -11,7 +11,7 @@ pub fn parse() -> Cli {
 #[command(about = "CLI client for the daemon", long_about = None)]
 pub struct Cli {
     /// Connect to a remote daemon over TCP (e.g. 127.0.0.1:9000)
-    #[arg(short = 'h', long = "host", value_name = "HOST", global = true)]
+    #[arg(short = 'H', long = "host", value_name = "HOST", global = true)]
     pub host: Option<String>,
 
     /// Path to the Unix socket to connect to

--- a/piquelctl/src/cli.rs
+++ b/piquelctl/src/cli.rs
@@ -32,4 +32,7 @@ pub struct Cli {
 pub enum Commands {
     /// Returns the hostname of the daemon
     Hostname,
+    Echo {
+        message: String,
+    },
 }

--- a/piquelctl/src/cli.rs
+++ b/piquelctl/src/cli.rs
@@ -1,0 +1,35 @@
+use clap::{Parser, Subcommand};
+use piquelcore::config::SOCKET_PATH;
+
+pub fn parse() -> Cli {
+    Cli::parse()
+}
+
+/// A CLI client for interacting with the daemon
+#[derive(Parser, Debug)]
+#[command(name = "piquelctl")]
+#[command(about = "CLI client for the daemon", long_about = None)]
+pub struct Cli {
+    /// Connect to a remote daemon over TCP (e.g. 127.0.0.1:9000)
+    #[arg(short = 'h', long = "host", value_name = "HOST", global = true)]
+    pub host: Option<String>,
+
+    /// Path to the Unix socket to connect to
+    #[arg(
+        short = 's',
+        long = "socket",
+        value_name = "SOCK",
+        default_value = SOCKET_PATH,
+        global = true
+    )]
+    pub socket: String,
+
+    #[command(subcommand)]
+    pub command: Commands,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum Commands {
+    /// Returns the hostname of the daemon
+    Hostname,
+}

--- a/piquelctl/src/main.rs
+++ b/piquelctl/src/main.rs
@@ -28,10 +28,12 @@ fn main() -> io::Result<()> {
 }
 
 fn handle_response(command: &Command, response: &Response) {
-    let resp_msg: &str = match response {
-        Response::Ok => "Ok",
-        Response::Message(message) => &format!("Message: \"{message}\""),
-        Response::Error(err) => &format!("Error: \"{err}\""),
-    };
-    println!("[client] Received {resp_msg}");
+    println!(
+        "{}",
+        match response {
+            Response::Ok => "Success",
+            Response::Message(message) => &message,
+            Response::Error(err) => &err,
+        }
+    );
 }

--- a/piquelctl/src/main.rs
+++ b/piquelctl/src/main.rs
@@ -1,7 +1,7 @@
 use std::io::{self};
 use std::panic;
 
-use piquelcore::ipc::client::{Client, TcpClient, UdsClient};
+use piquelcore::ipc::client::{IpcClient, TcpClient, UdsClient};
 use piquelcore::ipc::message::{Command, Response};
 
 mod cli;
@@ -9,12 +9,10 @@ mod cli;
 fn main() -> io::Result<()> {
     let cli = cli::parse();
 
-    let client;
-    if let Some(host) = cli.host {
-        client = TcpClient::new()?;
-    } else {
-        client = UdsClient::new()?;
-    }
+    let mut client: Box<dyn IpcClient> = match cli.host {
+        Some(addr) => Box::new(TcpClient::new(&addr)?),
+        None => Box::new(UdsClient::new(&cli.socket)?),
+    };
 
     let commands = [
         Command::Status,

--- a/piquelctl/src/main.rs
+++ b/piquelctl/src/main.rs
@@ -16,7 +16,7 @@ fn main() -> io::Result<()> {
     };
 
     let cmd = match &cli.command {
-        Commands::Hostname => Command::Status,
+        Commands::Hostname => Command::Hostname,
         Commands::Echo { message } => Command::Echo(message.to_string()),
     };
 

--- a/piquelctl/src/main.rs
+++ b/piquelctl/src/main.rs
@@ -1,7 +1,7 @@
 use std::io::{self};
 use std::panic;
 
-use piquelcore::ipc::client::{IpcClient, TcpClient, UdsClient};
+use piquelcore::ipc::client::Client;
 use piquelcore::ipc::message::{Command, Response};
 
 mod cli;
@@ -10,9 +10,9 @@ use cli::Commands;
 fn main() -> io::Result<()> {
     let cli = cli::parse();
 
-    let mut client: Box<dyn IpcClient> = match cli.host {
-        Some(addr) => Box::new(TcpClient::new(&addr)?),
-        None => Box::new(UdsClient::new(&cli.socket)?),
+    let mut client: Client = match cli.host {
+        Some(addr) => Client::new_tcp(&addr)?,
+        None => Client::new_uds(&cli.socket)?,
     };
 
     let cmd = match &cli.command {
@@ -21,17 +21,17 @@ fn main() -> io::Result<()> {
     };
 
     match client.send_command(&cmd) {
-        Ok(response) => {
-            let resp_msg: &str = match response {
-                Response::Ok => "Ok",
-                Response::Message(message) => &format!("Message: \"{message}\""),
-                Response::Error(err) => &format!("Error: \"{err}\""),
-            };
-            println!("[client] Received {resp_msg}");
-        }
+        Ok(response) => handle_response(&cmd, &response),
         Err(err) => panic!("{}", err),
     };
-
-    println!("[client] Done. Closing connection.");
     Ok(())
+}
+
+fn handle_response(command: &Command, response: &Response) {
+    let resp_msg: &str = match response {
+        Response::Ok => "Ok",
+        Response::Message(message) => &format!("Message: \"{message}\""),
+        Response::Error(err) => &format!("Error: \"{err}\""),
+    };
+    println!("[client] Received {resp_msg}");
 }

--- a/piquelctl/src/main.rs
+++ b/piquelctl/src/main.rs
@@ -5,6 +5,7 @@ use piquelcore::ipc::client::{IpcClient, TcpClient, UdsClient};
 use piquelcore::ipc::message::{Command, Response};
 
 mod cli;
+use cli::Commands;
 
 fn main() -> io::Result<()> {
     let cli = cli::parse();
@@ -14,27 +15,22 @@ fn main() -> io::Result<()> {
         None => Box::new(UdsClient::new(&cli.socket)?),
     };
 
-    let commands = [
-        Command::Status,
-        Command::Echo("Hello, server!".to_string()),
-        Command::Echo("How's IPC treating you?".to_string()),
-        Command::Echo("Goodbye!".to_string()),
-        Command::Stop,
-    ];
+    let cmd = match &cli.command {
+        Commands::Hostname => Command::Status,
+        Commands::Echo { message } => Command::Echo(message.to_string()),
+    };
 
-    for cmd in commands {
-        match client.send_command(&cmd) {
-            Ok(response) => {
-                let resp_msg: &str = match response {
-                    Response::Ok => "Ok",
-                    Response::Message(message) => &format!("Message: \"{message}\""),
-                    Response::Error(err) => &format!("Error: \"{err}\""),
-                };
-                println!("[client] Received: \"{resp_msg}\"");
-            }
-            Err(err) => panic!("{}", err),
-        };
-    }
+    match client.send_command(&cmd) {
+        Ok(response) => {
+            let resp_msg: &str = match response {
+                Response::Ok => "Ok",
+                Response::Message(message) => &format!("Message: \"{message}\""),
+                Response::Error(err) => &format!("Error: \"{err}\""),
+            };
+            println!("[client] Received {resp_msg}");
+        }
+        Err(err) => panic!("{}", err),
+    };
 
     println!("[client] Done. Closing connection.");
     Ok(())

--- a/piquelctl/src/main.rs
+++ b/piquelctl/src/main.rs
@@ -1,14 +1,20 @@
 use std::io::{self};
 use std::panic;
 
-use piquelcore::ipc::client::UdsClient;
+use piquelcore::ipc::client::{Client, TcpClient, UdsClient};
 use piquelcore::ipc::message::{Command, Response};
 
+mod cli;
+
 fn main() -> io::Result<()> {
-    let mut client = match UdsClient::new() {
-        Ok(client) => client,
-        Err(err) => panic!("{}", err),
-    };
+    let cli = cli::parse();
+
+    let client;
+    if let Some(host) = cli.host {
+        client = TcpClient::new()?;
+    } else {
+        client = UdsClient::new()?;
+    }
 
     let commands = [
         Command::Status,


### PR DESCRIPTION
Closes #5 

## Changes

- Add `Hostname` command. Not implemented yet as waiting for feature to hit stable in rust std.
- Move stuff around in `server::process_command`
- Setup CLI with [clap](https://github.com/clap-rs/clap)
- Removed basic sequence of commands
- Refactor Client API to store the stream in a `Box<>` instead of complicated generics
- Allow specifiing addresses in client creation

### CLI API

Flags:
- `-H`: specify a host for TCP connection
- `-s`: specify alternative path for socket

Commands:
- `hostname`: returns the hostname of the daemon
- `echo <message>`: echoes the message