### PR TITLE
Add configuration system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,6 +226,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "piquel-core",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,6 +234,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "piquel-core",
+ "serde",
  "tokio",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,6 +148,7 @@ dependencies = [
 name = "piqueld"
 version = "0.1.0"
 dependencies = [
+ "clap",
  "piquel-core",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-resolver = "2"
+resolver = "3"
 members = [
     "piquel-core",
     "piqueld",
@@ -9,3 +9,4 @@ members = [
 [workspace.dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1" }
+clap = { version = "4", features = ["derive"] }

--- a/piquel-core/src/config.rs
+++ b/piquel-core/src/config.rs
@@ -48,10 +48,10 @@ pub fn default_socket_path() -> PathBuf {
 
 /// Returns the default listen address
 pub fn default_listen_addr() -> String {
-    "0.0.0.0:7854".into()
+    String::from("0.0.0.0:7854")
 }
 
 /// Returns the default data dir
-pub fn default_data_dir() -> String {
-    "/var/lib/piqueld".into()
+pub fn default_data_dir() -> PathBuf {
+    PathBuf::from("/var/lib/piqueld")
 }

--- a/piquel-core/src/config.rs
+++ b/piquel-core/src/config.rs
@@ -1,5 +1,7 @@
 use std::path::{Path, PathBuf};
 
+pub mod defaults;
+
 #[derive(Debug)]
 pub enum ConfigError {
     AlreadyLoaded,
@@ -38,20 +40,4 @@ pub trait Config: serde::de::DeserializeOwned {
         Ok(config)
     }
     fn validate(&mut self) -> Result<(), ConfigError>;
-}
-
-/// Returns the default socket path
-pub fn default_socket_path() -> PathBuf {
-    // TODO: rename to "/run/piqueld.sock" when we run as root
-    PathBuf::from("/tmp/piqueld.sock")
-}
-
-/// Returns the default listen address
-pub fn default_listen_addr() -> String {
-    String::from("0.0.0.0:7854")
-}
-
-/// Returns the default data dir
-pub fn default_data_dir() -> PathBuf {
-    PathBuf::from("/var/lib/piqueld")
 }

--- a/piquel-core/src/config.rs
+++ b/piquel-core/src/config.rs
@@ -1,3 +1,24 @@
+use std::io;
+
+use serde::{Deserialize, Serialize};
+
 // TODO: rename to "/run/piqueld.sock" when we run as root
 pub const SOCKET_PATH: &str = "/tmp/piqueld.sock";
 pub const LISTEN_ADDR: &str = "0.0.0.0:7854";
+
+pub const DATA_DIR: &str = "/var/lib/piqueld";
+
+/// Settings for how to load configuration. This is mainly to accomodate for
+/// server and CLI configuration.
+///
+///
+pub struct ConfigLoadSetting {}
+
+#[derive(Serialize, Deserialize)]
+pub struct Config {}
+
+impl Config {
+    fn load() -> io::Result<Self> {
+        Ok(Config {})
+    }
+}

--- a/piquel-core/src/config.rs
+++ b/piquel-core/src/config.rs
@@ -35,7 +35,6 @@ pub trait Config: serde::de::DeserializeOwned {
         let mut config: Self =
             serde_json::from_str(&config_file).map_err(ConfigError::ParseError)?;
 
-        // `set` fails only if another thread raced us — treat that as already loaded.
         config.validate()?;
         Ok(config)
     }

--- a/piquel-core/src/config.rs
+++ b/piquel-core/src/config.rs
@@ -1,24 +1,57 @@
-use std::io;
+use std::path::{Path, PathBuf};
 
-use serde::{Deserialize, Serialize};
+#[derive(Debug)]
+pub enum ConfigError {
+    AlreadyLoaded,
+    FileNotFound(PathBuf),
+    ParseError(serde_json::Error),
+    Validation(String),
+}
 
-// TODO: rename to "/run/piqueld.sock" when we run as root
-pub const SOCKET_PATH: &str = "/tmp/piqueld.sock";
-pub const LISTEN_ADDR: &str = "0.0.0.0:7854";
-
-pub const DATA_DIR: &str = "/var/lib/piqueld";
-
-/// Settings for how to load configuration. This is mainly to accomodate for
-/// server and CLI configuration.
-///
-///
-pub struct ConfigLoadSetting {}
-
-#[derive(Serialize, Deserialize)]
-pub struct Config {}
-
-impl Config {
-    fn load() -> io::Result<Self> {
-        Ok(Config {})
+impl std::fmt::Display for ConfigError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ConfigError::AlreadyLoaded => {
+                write!(f, "Config has already been loaded")
+            }
+            ConfigError::FileNotFound(path) => {
+                write!(f, "Config file {path:?} does not exist")
+            }
+            ConfigError::ParseError(e) => write!(f, "Failed to parse config: {e}"),
+            ConfigError::Validation(msg) => write!(f, "{msg}"),
+        }
     }
+}
+
+impl std::error::Error for ConfigError {}
+
+pub trait Config: serde::de::DeserializeOwned {
+    fn load(config_path: &Path) -> Result<Self, ConfigError> {
+        let config_file = std::fs::read_to_string(config_path)
+            .map_err(|_| ConfigError::FileNotFound(config_path.to_owned()))?;
+
+        let mut config: Self =
+            serde_json::from_str(&config_file).map_err(ConfigError::ParseError)?;
+
+        // `set` fails only if another thread raced us — treat that as already loaded.
+        config.validate()?;
+        Ok(config)
+    }
+    fn validate(&mut self) -> Result<(), ConfigError>;
+}
+
+/// Returns the default socket path
+pub fn default_socket_path() -> PathBuf {
+    // TODO: rename to "/run/piqueld.sock" when we run as root
+    PathBuf::from("/tmp/piqueld.sock")
+}
+
+/// Returns the default listen address
+pub fn default_listen_addr() -> String {
+    "0.0.0.0:7854".into()
+}
+
+/// Returns the default data dir
+pub fn default_data_dir() -> String {
+    "/var/lib/piqueld".into()
 }

--- a/piquel-core/src/config/defaults.rs
+++ b/piquel-core/src/config/defaults.rs
@@ -1,0 +1,23 @@
+use std::path::PathBuf;
+
+pub fn socket_path() -> PathBuf {
+    // TODO: rename to "/run/piqueld.sock" when we run as root
+    PathBuf::from("/tmp/piqueld.sock")
+}
+
+pub fn listen_addr() -> String {
+    String::from("0.0.0.0:7854")
+}
+
+/// Returns the default data dir
+pub fn data_dir() -> PathBuf {
+    PathBuf::from("/var/lib/piqueld")
+}
+
+pub const SERVER_CONFIG_PATH: &str = "/etc/piqueld/config.json";
+
+pub fn client_config_path() -> PathBuf {
+    std::env::home_dir()
+        .unwrap()
+        .join(".config/piquel/config.json")
+}

--- a/piquel-core/src/config/defaults.rs
+++ b/piquel-core/src/config/defaults.rs
@@ -1,9 +1,8 @@
 use std::path::PathBuf;
 
-pub static SOCKET_PATH: &str = "/etc/piqueld/config.json";
 pub fn socket_path() -> PathBuf {
     // TODO: rename to "/run/piqueld.sock" when we run as root
-    PathBuf::from(SOCKET_PATH)
+    PathBuf::from("/etc/piqueld/config.json")
 }
 
 pub fn listen_addr() -> String {

--- a/piquel-core/src/config/defaults.rs
+++ b/piquel-core/src/config/defaults.rs
@@ -1,8 +1,9 @@
 use std::path::PathBuf;
 
+pub static SOCKET_PATH: &str = "/etc/piqueld/config.json";
 pub fn socket_path() -> PathBuf {
     // TODO: rename to "/run/piqueld.sock" when we run as root
-    PathBuf::from("/tmp/piqueld.sock")
+    PathBuf::from(SOCKET_PATH)
 }
 
 pub fn listen_addr() -> String {

--- a/piquel-core/src/ipc/client.rs
+++ b/piquel-core/src/ipc/client.rs
@@ -1,11 +1,13 @@
-use crate::ipc::ConnectionType;
+use crate::ipc::{
+    ConnectionType,
+    message::{Command, Response},
+};
 
-use super::message::{Command, Response};
 use std::{
     io::{self, Read, Write},
     net::TcpStream,
     os::unix::net::UnixStream,
-    usize,
+    path::Path,
 };
 
 trait ReadWrite: Write + Read {}
@@ -24,7 +26,7 @@ impl Client {
             client_type: ConnectionType::Tcp,
         })
     }
-    pub fn new_uds(path: &str) -> io::Result<Self> {
+    pub fn new_uds(path: &Path) -> io::Result<Self> {
         let stream = UnixStream::connect(path)?;
         Ok(Self {
             stream: Box::new(stream),

--- a/piquel-core/src/ipc/server.rs
+++ b/piquel-core/src/ipc/server.rs
@@ -1,21 +1,17 @@
-use crate::config::{LISTEN_ADDR, SOCKET_PATH};
 use crate::ipc::message::{Command, Response};
-use std::path::Path;
+use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tokio::net::{TcpListener, UnixListener};
 
 pub struct Server {
-    uds_path: &'static str,
-    tcp_addr: &'static str,
+    uds_path: PathBuf,
+    tcp_addr: String,
 }
 
 impl Server {
-    pub fn new() -> Self {
-        Server {
-            uds_path: SOCKET_PATH,
-            tcp_addr: LISTEN_ADDR,
-        }
+    pub fn new(tcp_addr: String, uds_path: PathBuf) -> Self {
+        Server { uds_path, tcp_addr }
     }
     pub async fn listen(self) -> tokio::io::Result<()> {
         let server = Arc::new(self);
@@ -23,7 +19,7 @@ impl Server {
         Ok(())
     }
     async fn listen_tcp(self: Arc<Self>) -> tokio::io::Result<()> {
-        let listener = TcpListener::bind(self.tcp_addr).await?;
+        let listener = TcpListener::bind(&self.tcp_addr).await?;
         println!("[TCP] Listening on {}", self.tcp_addr);
         loop {
             let (stream, _) = listener.accept().await?;
@@ -32,11 +28,11 @@ impl Server {
         }
     }
     async fn listen_uds(self: Arc<Self>) -> tokio::io::Result<()> {
-        if Path::new(self.uds_path).exists() {
-            std::fs::remove_file(self.uds_path)?;
+        if self.uds_path.exists() {
+            std::fs::remove_file(&self.uds_path)?;
         }
-        let listener = UnixListener::bind(self.uds_path)?;
-        println!("[UDS] Listening on {}", self.uds_path);
+        let listener = UnixListener::bind(&self.uds_path)?;
+        println!("[UDS] Listening on {:?}", self.uds_path);
         loop {
             let (stream, _) = listener.accept().await?;
             let server = Arc::clone(&self);

--- a/piquelctl/Cargo.toml
+++ b/piquelctl/Cargo.toml
@@ -7,3 +7,4 @@ default-run = "piquelctl"
 [dependencies]
 piquel-core = { path = "../piquel-core/" }
 clap.workspace = true
+serde.workspace = true

--- a/piquelctl/Cargo.toml
+++ b/piquelctl/Cargo.toml
@@ -6,4 +6,4 @@ default-run = "piquelctl"
 
 [dependencies]
 piquel-core = { path = "../piquel-core/" }
-clap = { version = "4", features = ["derive"] }
+clap.workspace = true

--- a/piquelctl/src/cli.rs
+++ b/piquelctl/src/cli.rs
@@ -1,5 +1,7 @@
+use std::path::PathBuf;
+
 use clap::{Parser, Subcommand};
-use piquelcore::config::SOCKET_PATH;
+use piquelcore::config::defaults;
 
 pub fn parse() -> Cli {
     Cli::parse()
@@ -18,11 +20,11 @@ pub struct Cli {
     #[arg(
         short = 's',
         long = "socket",
-        value_name = "SOCK",
-        default_value = SOCKET_PATH,
+        value_name = "sock",
+        default_value = defaults::SOCKET_PATH,
         global = true
     )]
-    pub socket: String,
+    pub socket: PathBuf,
 
     #[command(subcommand)]
     pub command: Commands,

--- a/piquelctl/src/cli.rs
+++ b/piquelctl/src/cli.rs
@@ -1,7 +1,6 @@
 use std::path::PathBuf;
 
 use clap::{Parser, Subcommand};
-use piquelcore::config::defaults;
 
 pub fn parse() -> Cli {
     Cli::parse()
@@ -12,19 +11,17 @@ pub fn parse() -> Cli {
 #[command(name = "piquelctl")]
 #[command(about = "CLI for piqueld", long_about = None)]
 pub struct Cli {
+    /// Custom path to configuration
+    #[arg(long = "config", value_name = "path", global = true)]
+    pub config_path: Option<PathBuf>,
+
     /// Connect to a remote daemon over TCP (e.g. 127.0.0.1:7854)
     #[arg(short = 'H', long = "host", value_name = "HOST", global = true)]
     pub host: Option<String>,
 
     /// Path to the Unix socket to connect to
-    #[arg(
-        short = 's',
-        long = "socket",
-        value_name = "sock",
-        default_value = defaults::SOCKET_PATH,
-        global = true
-    )]
-    pub socket: PathBuf,
+    #[arg(short = 's', long = "socket", value_name = "sock", global = true)]
+    pub socket: Option<PathBuf>,
 
     #[command(subcommand)]
     pub command: Commands,

--- a/piquelctl/src/config.rs
+++ b/piquelctl/src/config.rs
@@ -1,0 +1,10 @@
+use std::path::PathBuf;
+
+use piquelcore::config;
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+pub struct ClientConfig {
+    #[serde(default = "config::default_socket_path")]
+    pub socket_path: PathBuf,
+}

--- a/piquelctl/src/config.rs
+++ b/piquelctl/src/config.rs
@@ -1,10 +1,16 @@
 use std::path::PathBuf;
 
-use piquelcore::config;
+use piquelcore::config::{self, Config};
 use serde::Deserialize;
 
 #[derive(Deserialize)]
 pub struct ClientConfig {
     #[serde(default = "config::defaults::socket_path")]
     pub socket_path: PathBuf,
+}
+
+impl Config for ClientConfig {
+    fn validate(&mut self) -> Result<(), config::ConfigError> {
+        Ok(())
+    }
 }

--- a/piquelctl/src/config.rs
+++ b/piquelctl/src/config.rs
@@ -5,6 +5,6 @@ use serde::Deserialize;
 
 #[derive(Deserialize)]
 pub struct ClientConfig {
-    #[serde(default = "config::default_socket_path")]
+    #[serde(default = "config::defaults::socket_path")]
     pub socket_path: PathBuf,
 }

--- a/piquelctl/src/main.rs
+++ b/piquelctl/src/main.rs
@@ -1,6 +1,6 @@
-use std::io::{self};
 use std::panic;
 
+use piquelcore::config::{Config, defaults};
 use piquelcore::ipc::client::Client;
 use piquelcore::ipc::message::{Command, Response};
 
@@ -9,12 +9,25 @@ use cli::Commands;
 mod cli;
 mod config;
 
-fn main() -> io::Result<()> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = cli::parse();
+
+    let config_path = match cli.config_path {
+        Some(path) => path,
+        None => defaults::client_config_path(),
+    };
+
+    let socket_path = match cli.socket {
+        Some(path) => path,
+        None => match config::ClientConfig::load(&config_path) {
+            Ok(config) => config.socket_path,
+            Err(_) => defaults::socket_path(),
+        },
+    };
 
     let mut client: Client = match cli.host {
         Some(addr) => Client::new_tcp(&addr)?,
-        None => Client::new_uds(&cli.socket)?,
+        None => Client::new_uds(&socket_path)?,
     };
 
     let cmd = match &cli.command {

--- a/piquelctl/src/main.rs
+++ b/piquelctl/src/main.rs
@@ -4,8 +4,10 @@ use std::panic;
 use piquelcore::ipc::client::Client;
 use piquelcore::ipc::message::{Command, Response};
 
-mod cli;
 use cli::Commands;
+
+mod config;
+mod cli;
 
 fn main() -> io::Result<()> {
     let cli = cli::parse();

--- a/piquelctl/src/main.rs
+++ b/piquelctl/src/main.rs
@@ -6,8 +6,8 @@ use piquelcore::ipc::message::{Command, Response};
 
 use cli::Commands;
 
-mod config;
 mod cli;
+mod config;
 
 fn main() -> io::Result<()> {
     let cli = cli::parse();

--- a/piquelctl/src/main.rs
+++ b/piquelctl/src/main.rs
@@ -17,11 +17,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         None => defaults::client_config_path(),
     };
 
+    let config = match config::ClientConfig::load(&config_path) {
+        Ok(config) => Some(config),
+        Err(_) => None,
+    };
+
     let socket_path = match cli.socket {
         Some(path) => path,
-        None => match config::ClientConfig::load(&config_path) {
-            Ok(config) => config.socket_path,
-            Err(_) => defaults::socket_path(),
+        None => match config {
+            Some(config) => config.socket_path,
+            None => defaults::socket_path(),
         },
     };
 

--- a/piqueld/Cargo.toml
+++ b/piqueld/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2024"
 piquel-core = { path = "../piquel-core/" }
 clap.workspace = true
 tokio.workspace = true
+serde.workspace = true

--- a/piqueld/Cargo.toml
+++ b/piqueld/Cargo.toml
@@ -5,3 +5,4 @@ edition = "2024"
 
 [dependencies]
 piquel-core = { path = "../piquel-core/" }
+clap.workspace = true

--- a/piqueld/src/config.rs
+++ b/piqueld/src/config.rs
@@ -5,11 +5,11 @@ use serde::{self, Deserialize};
 
 #[derive(Deserialize)]
 pub struct ServerConfig {
-    #[serde(default = "config::default_data_dir")]
+    #[serde(default = "config::defaults::data_dir")]
     pub data_dir: PathBuf,
-    #[serde(default = "config::default_socket_path")]
+    #[serde(default = "config::defaults::socket_path")]
     pub socket_path: PathBuf,
-    #[serde(default = "config::default_listen_addr")]
+    #[serde(default = "config::defaults::listen_addr")]
     pub listen_addr: String,
 }
 
@@ -19,4 +19,3 @@ impl Config for ServerConfig {
     }
 }
 
-pub const DEFAULT_CONFIG_PATH: &str = "/etc/piqueld/config.json";

--- a/piqueld/src/config.rs
+++ b/piqueld/src/config.rs
@@ -1,0 +1,14 @@
+use std::path::PathBuf;
+
+use piquelcore::config;
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+pub struct ServerConfig {
+    #[serde(default = "config::default_data_dir")]
+    pub data_dir: PathBuf,
+    #[serde(default = "config::default_socket_path")]
+    pub socket_path: PathBuf,
+    #[serde(default = "config::default_listen_addr")]
+    pub listen_addr: String,
+}

--- a/piqueld/src/config.rs
+++ b/piqueld/src/config.rs
@@ -18,4 +18,3 @@ impl Config for ServerConfig {
         Ok(())
     }
 }
-

--- a/piqueld/src/config.rs
+++ b/piqueld/src/config.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
-use piquelcore::config;
-use serde::Deserialize;
+use piquelcore::config::{self, Config};
+use serde::{self, Deserialize};
 
 #[derive(Deserialize)]
 pub struct ServerConfig {
@@ -12,3 +12,11 @@ pub struct ServerConfig {
     #[serde(default = "config::default_listen_addr")]
     pub listen_addr: String,
 }
+
+impl Config for ServerConfig {
+    fn validate(&mut self) -> Result<(), config::ConfigError> {
+        Ok(())
+    }
+}
+
+pub const DEFAULT_CONFIG_PATH: &str = "/etc/piqueld/config.json";

--- a/piqueld/src/main.rs
+++ b/piqueld/src/main.rs
@@ -2,6 +2,8 @@ use std::io;
 
 use piquelcore::ipc::server::Server;
 
+mod config;
+
 #[tokio::main]
 async fn main() -> io::Result<()> {
     Server::new().listen().await

--- a/piqueld/src/main.rs
+++ b/piqueld/src/main.rs
@@ -1,10 +1,33 @@
-use std::io;
+use clap::Parser;
+use std::path::PathBuf;
 
-use piquelcore::ipc::server::Server;
+use piquelcore::{config::Config, ipc::server::Server};
+
+use crate::config::DEFAULT_CONFIG_PATH;
 
 mod config;
 
+#[derive(Parser, Debug)]
+#[command(name = "piquelctl")]
+#[command(about = "CLI for piqueld", long_about = None)]
+pub struct Cli {
+    /// Custom path to configuration
+    #[arg(long = "config", value_name = "path", global = true)]
+    config_path: Option<PathBuf>,
+}
+
 #[tokio::main]
-async fn main() -> io::Result<()> {
-    Server::new().listen().await
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let cli = Cli::parse();
+
+    let config_path: &PathBuf = match &cli.config_path {
+        Some(path) => path,
+        None => &PathBuf::from(DEFAULT_CONFIG_PATH),
+    };
+
+    let config = config::ServerConfig::load(config_path)?;
+
+    Ok(Server::new(config.listen_addr, config.socket_path)
+        .listen()
+        .await?)
 }

--- a/piqueld/src/main.rs
+++ b/piqueld/src/main.rs
@@ -1,9 +1,10 @@
 use clap::Parser;
 use std::path::PathBuf;
 
-use piquelcore::{config::Config, ipc::server::Server};
-
-use crate::config::DEFAULT_CONFIG_PATH;
+use piquelcore::{
+    config::{Config, defaults},
+    ipc::server::Server,
+};
 
 mod config;
 
@@ -12,20 +13,18 @@ mod config;
 #[command(about = "CLI for piqueld", long_about = None)]
 pub struct Cli {
     /// Custom path to configuration
-    #[arg(long = "config", value_name = "path", global = true)]
-    config_path: Option<PathBuf>,
+    #[arg(long = "config",
+        value_name = "path",
+        global = true,
+        default_value = defaults::SERVER_CONFIG_PATH
+        )]
+    config_path: PathBuf,
 }
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
-
-    let config_path: &PathBuf = match &cli.config_path {
-        Some(path) => path,
-        None => &PathBuf::from(DEFAULT_CONFIG_PATH),
-    };
-
-    let config = config::ServerConfig::load(config_path)?;
+    let config = config::ServerConfig::load(&cli.config_path)?;
 
     Ok(Server::new(config.listen_addr, config.socket_path)
         .listen()


### PR DESCRIPTION
Closes #2 

Setup configuration system. Both daemon and client have their own config.
`piqueld`: `/etc/piqueld/config.json`
`piquelctl`: `~/.config/piquel/config.json`
Both of these paths can be overriden with the `--config <path>` flag.

## Changes

- Add `core::config::defaults` module with constants and functions for default values
- use `Path` & `PathBuf` in more locations of server and client. It is better than `&str`.
- Setup `Config` trait and `ConfigError` for loading & validation.

### `ClientConfig`

`socket_path`: overrides the default socket path. CLI flag still takes precedence.

### `ServerConfig`

- `data_dir`: Will be used in the future.
- `socket_path` & `listen_addr`: configuration for the server listener.