### PR TITLE
QoL update to config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ target
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Config file used during development
+config.json

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -37,7 +37,7 @@ in
 
     ctlSettings = lib.mkOption {
       description = "The configuration passed to the control cli";
-      default = {};
+      default = { };
       type = lib.types.submodule {
         freeformType = settingsFormat.type;
         options =
@@ -45,10 +45,25 @@ in
             inherit (lib) mkOption types;
           in
           {
-            socket_path = mkOption {
+            socket = mkOption {
               type = types.str;
               default = "/run/piqueld/piqueld.sock";
               description = "Path to the socket";
+            };
+            address = mkOption {
+              type = types.str;
+              default = "0.0.0.0";
+              description = "Address to listen to";
+            };
+            port = mkOption {
+              type = types.int;
+              default = 7854;
+              description = "Port on which to listen to";
+            };
+            default_to_tcp = mkOption {
+              type = types.bool;
+              default = false;
+              description = "Whether to connect to TCP socket by default.";
             };
           };
       };
@@ -76,7 +91,7 @@ in
 
     daemonSettings = lib.mkOption {
       description = "The configuration passed to the daemon";
-      default = {};
+      default = { };
       type = lib.types.submodule {
         freeformType = settingsFormat.type;
         options =
@@ -102,7 +117,7 @@ in
             port = mkOption {
               type = types.int;
               default = 7854;
-              description = "Address to listen to";
+              description = "Port on which to listen to";
             };
           };
       };

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -89,14 +89,19 @@ in
               default = "/var/lib/piqueld";
               description = "Path to daemon data";
             };
-            socket_path = mkOption {
+            socket = mkOption {
               type = types.str;
               default = "/run/piqueld/piqueld.sock";
               description = "Path to the socket";
             };
-            listen_addr = mkOption {
+            address = mkOption {
               type = types.str;
-              default = "0.0.0.0:7854";
+              default = "0.0.0.0";
+              description = "Address to listen to";
+            };
+            port = mkOption {
+              type = types.int;
+              default = 7854;
               description = "Address to listen to";
             };
           };

--- a/piquel-core/src/config/defaults.rs
+++ b/piquel-core/src/config/defaults.rs
@@ -6,7 +6,10 @@ pub fn socket_path() -> PathBuf {
 }
 
 pub fn listen_addr() -> String {
-    String::from("0.0.0.0:7854")
+    String::from("0.0.0.0")
+}
+pub fn listen_port() -> u16 {
+    7854
 }
 
 /// Returns the default data dir

--- a/piquel-core/src/config/defaults.rs
+++ b/piquel-core/src/config/defaults.rs
@@ -1,14 +1,16 @@
 use std::path::PathBuf;
 
 pub fn socket_path() -> PathBuf {
-    // TODO: rename to "/run/piqueld.sock" when we run as root
-    PathBuf::from("/etc/piqueld/config.json")
+    PathBuf::from("/run/piqueld/piqueld.sock")
 }
 
 pub fn listen_addr() -> String {
     String::from("0.0.0.0")
 }
-pub fn listen_port() -> u16 {
+pub fn localhost() -> String {
+    String::from("127.0.0.1")
+}
+pub fn port() -> u16 {
     7854
 }
 

--- a/piquel-core/src/ipc/server.rs
+++ b/piquel-core/src/ipc/server.rs
@@ -6,12 +6,17 @@ use tokio::net::{TcpListener, UnixListener};
 
 pub struct Server {
     uds_path: PathBuf,
-    tcp_addr: String,
+    address: String,
+    port: u16,
 }
 
 impl Server {
-    pub fn new(tcp_addr: String, uds_path: PathBuf) -> Self {
-        Server { uds_path, tcp_addr }
+    pub fn new((address, port): (String, u16), uds_path: PathBuf) -> Self {
+        Server {
+            uds_path,
+            address,
+            port,
+        }
     }
     pub async fn listen(self) -> tokio::io::Result<()> {
         let server = Arc::new(self);
@@ -19,8 +24,9 @@ impl Server {
         Ok(())
     }
     async fn listen_tcp(self: Arc<Self>) -> tokio::io::Result<()> {
-        let listener = TcpListener::bind(&self.tcp_addr).await?;
-        println!("[TCP] Listening on {}", self.tcp_addr);
+        let addr = format!("{}:{}", self.address, self.port);
+        let listener = TcpListener::bind(&addr).await?;
+        println!("[TCP] Listening on {addr}");
         loop {
             let (stream, _) = listener.accept().await?;
             let server = Arc::clone(&self);

--- a/piquelctl/src/cli.rs
+++ b/piquelctl/src/cli.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use clap::{Parser, Subcommand};
+use clap::{ArgGroup, Parser, Subcommand};
 
 pub fn parse() -> Cli {
     Cli::parse()
@@ -10,6 +10,12 @@ pub fn parse() -> Cli {
 #[derive(Parser, Debug)]
 #[command(name = "piquelctl")]
 #[command(about = "CLI for piqueld", long_about = None)]
+#[command(group(
+    ArgGroup::new("transport")
+        .args(["uds", "tcp"])
+        .multiple(false)  // ensures mutual exclusivity
+        .required(false)  // neither is required
+))]
 pub struct Cli {
     /// Custom path to configuration
     #[arg(long = "config", value_name = "path", global = true)]
@@ -22,6 +28,13 @@ pub struct Cli {
     /// Path to the Unix socket to connect to
     #[arg(short = 's', long = "socket", value_name = "sock", global = true)]
     pub socket: Option<PathBuf>,
+
+    /// Use Unix Domain Socket transport
+    #[arg(long = "uds", global = true)]
+    pub uds: bool,
+    /// Use TCP transport
+    #[arg(long = "tcp", global = true)]
+    pub tcp: bool,
 
     #[command(subcommand)]
     pub command: Commands,

--- a/piquelctl/src/config.rs
+++ b/piquelctl/src/config.rs
@@ -6,7 +6,13 @@ use serde::Deserialize;
 #[derive(Deserialize)]
 pub struct ClientConfig {
     #[serde(default = "config::defaults::socket_path")]
-    pub socket_path: PathBuf,
+    pub socket: PathBuf,
+    #[serde(default = "config::defaults::listen_addr")]
+    pub address: String,
+    #[serde(default = "config::defaults::listen_port")]
+    pub port: u16,
+
+    pub default_to_tcp: bool,
 }
 
 impl Config for ClientConfig {

--- a/piquelctl/src/config.rs
+++ b/piquelctl/src/config.rs
@@ -7,9 +7,9 @@ use serde::Deserialize;
 pub struct ClientConfig {
     #[serde(default = "config::defaults::socket_path")]
     pub socket: PathBuf,
-    #[serde(default = "config::defaults::listen_addr")]
+    #[serde(default = "config::defaults::localhost")]
     pub address: String,
-    #[serde(default = "config::defaults::listen_port")]
+    #[serde(default = "config::defaults::port")]
     pub port: u16,
 
     pub default_to_tcp: bool,

--- a/piquelctl/src/main.rs
+++ b/piquelctl/src/main.rs
@@ -56,10 +56,17 @@ fn create_client(config: &Option<ClientConfig>, cli: &Cli) -> io::Result<Client>
         },
     };
 
-    let uds_client: bool = match config {
+    let mut uds_client: bool = match config {
         Some(config) => !config.default_to_tcp,
         None => true,
     };
+
+    if cli.uds {
+        uds_client = true;
+    }
+    if cli.tcp {
+        uds_client = false;
+    }
 
     Ok(if uds_client {
         Client::new_uds(&socket_path)?

--- a/piquelctl/src/main.rs
+++ b/piquelctl/src/main.rs
@@ -1,4 +1,4 @@
-use std::panic;
+use std::{io, panic};
 
 use piquelcore::config::{Config, defaults};
 use piquelcore::ipc::client::Client;
@@ -6,15 +6,18 @@ use piquelcore::ipc::message::{Command, Response};
 
 use cli::Commands;
 
+use crate::cli::Cli;
+use crate::config::ClientConfig;
+
 mod cli;
 mod config;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = cli::parse();
 
-    let config_path = match cli.config_path {
+    let config_path = match &cli.config_path {
         Some(path) => path,
-        None => defaults::client_config_path(),
+        None => &defaults::client_config_path(),
     };
 
     let config = match config::ClientConfig::load(&config_path) {
@@ -22,18 +25,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         Err(_) => None,
     };
 
-    let socket_path = match cli.socket {
-        Some(path) => path,
-        None => match config {
-            Some(config) => config.socket_path,
-            None => defaults::socket_path(),
-        },
-    };
-
-    let mut client: Client = match cli.host {
-        Some(addr) => Client::new_tcp(&addr)?,
-        None => Client::new_uds(&socket_path)?,
-    };
+    let mut client = create_client(&config, &cli)?;
 
     let cmd = match &cli.command {
         Commands::Hostname => Command::Hostname,
@@ -45,6 +37,35 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         Err(err) => panic!("{}", err),
     };
     Ok(())
+}
+
+fn create_client(config: &Option<ClientConfig>, cli: &Cli) -> io::Result<Client> {
+    let socket_path = match &cli.socket {
+        Some(path) => path,
+        None => match config {
+            Some(config) => &config.socket,
+            None => &defaults::socket_path(),
+        },
+    };
+
+    let tcp_addr = match &cli.host {
+        Some(addr) => addr,
+        None => &match config {
+            Some(config) => format!("{}:{}", config.address, config.port),
+            None => format!("{}:{}", defaults::localhost(), defaults::port()),
+        },
+    };
+
+    let uds_client: bool = match config {
+        Some(config) => !config.default_to_tcp,
+        None => true,
+    };
+
+    Ok(if uds_client {
+        Client::new_uds(&socket_path)?
+    } else {
+        Client::new_tcp(&tcp_addr)?
+    })
 }
 
 fn handle_response(command: &Command, response: &Response) {

--- a/piqueld/src/config.rs
+++ b/piqueld/src/config.rs
@@ -11,7 +11,7 @@ pub struct ServerConfig {
     pub socket: PathBuf,
     #[serde(default = "config::defaults::listen_addr")]
     pub address: String,
-    #[serde(default = "config::defaults::listen_port")]
+    #[serde(default = "config::defaults::port")]
     pub port: u16,
 }
 

--- a/piqueld/src/config.rs
+++ b/piqueld/src/config.rs
@@ -8,9 +8,11 @@ pub struct ServerConfig {
     #[serde(default = "config::defaults::data_dir")]
     pub data_dir: PathBuf,
     #[serde(default = "config::defaults::socket_path")]
-    pub socket_path: PathBuf,
+    pub socket: PathBuf,
     #[serde(default = "config::defaults::listen_addr")]
-    pub listen_addr: String,
+    pub address: String,
+    #[serde(default = "config::defaults::listen_port")]
+    pub port: u16,
 }
 
 impl Config for ServerConfig {

--- a/piqueld/src/main.rs
+++ b/piqueld/src/main.rs
@@ -26,7 +26,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
     let config = config::ServerConfig::load(&cli.config_path)?;
 
-    Ok(Server::new(config.listen_addr, config.socket_path)
+    Ok(Server::new((config.address, config.port), config.socket)
         .listen()
         .await?)
 }


### PR DESCRIPTION
Closes #10 

## TODO

- [x] Server config
- [x] Client config
- [x] Add `--uds` & `--tcp` flags to force connection type without needing to specify path/addr

## Changes

- Rename all `socket_path` to `socket` in all config
- Split tcp address to address & port in all config
- Add `default_to_tcp` to `ClientConfig`
- Update NixOS module accordingly
- Update cli with new `--uds` & `--tcp` flags to force a transport method.
- Refactor & cleanup client type selection logic with new configuration & cli flags