### PR TITLE
Add logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,7 +123,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
- "serde_core",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,6 +247,7 @@ name = "piquelctl"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "log",
  "piquel-core",
  "serde",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,6 +257,7 @@ name = "piqueld"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "log",
  "piquel-core",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,6 +117,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -183,6 +192,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+
+[[package]]
 name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -224,6 +239,7 @@ dependencies = [
  "log",
  "serde",
  "serde_json",
+ "time",
 ]
 
 [[package]]
@@ -245,6 +261,12 @@ dependencies = [
  "serde_json",
  "tokio",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "proc-macro2"
@@ -364,6 +386,25 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "tokio"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,7 +38,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -49,7 +49,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -72,9 +72,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
-version = "4.5.59"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5caf74d17c3aec5495110c34cc3f78644bfa89af6c8993ed4de2790e49b6499"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -82,9 +82,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.59"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "370daa45065b80218950227371916a1633217ae42b2715b2287b606dcd618e24"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
 dependencies = [
  "anstream",
  "anstyle",
@@ -123,6 +123,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+ "serde_core",
 ]
 
 [[package]]
@@ -132,7 +133,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -188,7 +189,7 @@ checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -279,9 +280,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -362,12 +363,12 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -378,9 +379,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.116"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3df424c70518695237746f84cede799c9c58fcb37450d7b23716568cc8bc69cb"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -394,10 +395,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
+ "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -405,6 +408,16 @@ name = "time-core"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
 
 [[package]]
 name = "tokio"
@@ -420,7 +433,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -460,86 +473,12 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "zmij"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,6 +160,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -215,6 +221,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 name = "piquel-core"
 version = "0.1.0"
 dependencies = [
+ "log",
  "serde",
  "serde_json",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1" }
 clap = { version = "4", features = ["derive"] }
 log = { version = "0.4", features = ["std"] }
-time = { version = "0.3.47" }
+time = { version = "0.3.47", features = ["formatting", "serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,4 @@ tokio = { version = "1.50", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1" }
 clap = { version = "4", features = ["derive"] }
+log = { version = "0.4", features = ["std"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1" }
 clap = { version = "4", features = ["derive"] }
 log = { version = "0.4", features = ["std"] }
+time = { version = "0.3.47" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1" }
 clap = { version = "4", features = ["derive"] }
 log = { version = "0.4", features = ["std"] }
-time = { version = "0.3.47", features = ["formatting", "serde"] }
+time = { version = "0.3.47", features = ["formatting"] }

--- a/piquel-core/Cargo.toml
+++ b/piquel-core/Cargo.toml
@@ -8,5 +8,6 @@ name = "piquelcore"
 
 [dependencies]
 log.workspace = true
+time.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/piquel-core/Cargo.toml
+++ b/piquel-core/Cargo.toml
@@ -7,5 +7,6 @@ edition = "2024"
 name = "piquelcore"
 
 [dependencies]
+log.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/piquel-core/src/ipc.rs
+++ b/piquel-core/src/ipc.rs
@@ -6,3 +6,16 @@ pub enum ConnectionType {
     Tcp,
     Uds,
 }
+
+impl std::fmt::Display for ConnectionType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Tcp => {
+                write!(f, "TCP")
+            }
+            Self::Uds => {
+                write!(f, "UDS")
+            }
+        }
+    }
+}

--- a/piquel-core/src/ipc/client.rs
+++ b/piquel-core/src/ipc/client.rs
@@ -1,3 +1,5 @@
+use log::debug;
+
 use crate::ipc::{
     ConnectionType,
     message::{Command, Response},
@@ -21,19 +23,26 @@ pub struct Client {
 impl Client {
     pub fn new_tcp(addr: &str) -> io::Result<Self> {
         let stream = TcpStream::connect(addr)?;
-        Ok(Self {
-            stream: Box::new(stream),
-            client_type: ConnectionType::Tcp,
-        })
+        Ok(Client::new(Box::new(stream), addr, ConnectionType::Tcp))
     }
     pub fn new_uds(path: &Path) -> io::Result<Self> {
         let stream = UnixStream::connect(path)?;
-        Ok(Self {
-            stream: Box::new(stream),
-            client_type: ConnectionType::Uds,
-        })
+        Ok(Client::new(
+            Box::new(stream),
+            &path.to_string_lossy(),
+            ConnectionType::Uds,
+        ))
+    }
+    fn new(stream: Box<dyn ReadWrite>, addr: &str, client_type: ConnectionType) -> Self {
+        debug!("[{client_type:#}] Connected to server on {addr}");
+        Client {
+            stream,
+            client_type,
+        }
     }
     pub fn send_command(&mut self, command: &Command) -> io::Result<Response> {
+        debug!("[{:#}] Sending command: {}", self.client_type, command);
+
         let request = serde_json::to_vec(&command)?;
         let len = (request.len() as u32).to_be_bytes();
         self.stream.write_all(&len)?;

--- a/piquel-core/src/ipc/message.rs
+++ b/piquel-core/src/ipc/message.rs
@@ -9,6 +9,28 @@ pub enum Command {
     Stop,
 }
 
+impl std::fmt::Display for Command {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Echo(msg) => {
+                write!(f, "Echo \"{msg}\"")
+            }
+            Self::Status => {
+                write!(f, "Status")
+            }
+            Self::Hostname => {
+                write!(f, "Hostname")
+            }
+            Self::Reload => {
+                write!(f, "Reload")
+            }
+            Self::Stop => {
+                write!(f, "Stop")
+            }
+        }
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub enum Response {
     Ok,

--- a/piquel-core/src/lib.rs
+++ b/piquel-core/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod config;
 pub mod ipc;
+pub mod logging;

--- a/piquel-core/src/logging.rs
+++ b/piquel-core/src/logging.rs
@@ -1,0 +1,1 @@
+pub mod logger;

--- a/piquel-core/src/logging.rs
+++ b/piquel-core/src/logging.rs
@@ -1,1 +1,11 @@
+use crate::logging::logger::Logger;
+
 pub mod logger;
+
+pub fn init(logger: Box<Logger>) -> Result<(), Box<dyn std::error::Error>> {
+    let max_level = logger.max_level().to_level_filter();
+    log::set_boxed_logger(logger)?;
+    log::set_max_level(max_level);
+
+    Ok(())
+}

--- a/piquel-core/src/logging/logger.rs
+++ b/piquel-core/src/logging/logger.rs
@@ -60,6 +60,33 @@ impl log::Log for Logger {
 }
 
 fn format_log_level(level: Level) -> String {
-    // TODO: color the string
-    format!("[{}]", level.to_string())
+    format!(
+        "[{}]",
+        make_colored_message(level.into(), &level.to_string())
+    )
+}
+
+impl From<Level> for Color {
+    fn from(level: Level) -> Self {
+        match level {
+            Level::Error => Color::Red,
+            Level::Warn => Color::Yellow,
+            Level::Info => Color::Green,
+            Level::Debug => Color::Blue,
+            Level::Trace => Color::Cyan,
+        }
+    }
+}
+
+enum Color {
+    Cyan = 36,
+    //Magenta = 35,
+    Blue = 34,
+    Yellow = 33,
+    Green = 32,
+    Red = 31,
+}
+
+fn make_colored_message(color: Color, message: &str) -> String {
+    format!("\x1b[{}m{}\x1b[0m", color as usize, message)
 }

--- a/piquel-core/src/logging/logger.rs
+++ b/piquel-core/src/logging/logger.rs
@@ -4,24 +4,20 @@ use time::{self, OffsetDateTime};
 pub struct Logger {
     enable: bool,
     max_level: Level,
-    date_time: bool,
-}
-
-pub fn init(logger: Box<Logger>) -> Result<(), Box<dyn std::error::Error>> {
-    let max_level = logger.max_level.to_level_filter();
-    log::set_boxed_logger(logger)?;
-    log::set_max_level(max_level);
-
-    Ok(())
+    prefix: bool,
 }
 
 impl Logger {
-    pub fn new(enable: bool, max_level: Level, date_time: bool) -> Self {
+    pub fn new(enable: bool, verbose: bool, prefix: bool) -> Self {
+        let max_level = if verbose { Level::Info } else { Level::Trace };
         Logger {
             enable,
             max_level,
-            date_time,
+            prefix,
         }
+    }
+    pub fn max_level(&self) -> Level {
+        self.max_level
     }
 }
 
@@ -37,6 +33,7 @@ impl log::Log for Logger {
         if !self.enabled(record.metadata()) {
             return;
         }
+
         let now = OffsetDateTime::now_utc();
         let fmt = time::format_description::parse("[year]/[month]/[day] [hour]:[minute]:[second]")
             .unwrap();
@@ -44,13 +41,13 @@ impl log::Log for Logger {
         let timestamp = now.format(&fmt).unwrap();
         let log_level = format_log_level(record.level());
 
-        let prefix = if self.date_time {
-            format!("{} {}", timestamp, log_level)
-        } else {
-            log_level
-        };
+        let prefix = format!("{} {}", timestamp, log_level);
 
-        let msg = format!("{} {}", prefix, record.args());
+        let msg = if self.prefix {
+            format!("{} {}", prefix, record.args())
+        } else {
+            record.args().to_string()
+        };
 
         if record.level() == Level::Error {
             println!("{msg}");

--- a/piquel-core/src/logging/logger.rs
+++ b/piquel-core/src/logging/logger.rs
@@ -54,7 +54,6 @@ impl log::Log for Logger {
             eprintln!("{msg}");
         }
     }
-
     fn flush(&self) {}
 }
 
@@ -96,9 +95,9 @@ fn date_time_format() -> Vec<time::format_description::BorrowedFormatItem<'stati
 
 #[cfg(test)]
 mod tests {
+    /// Making sure the unwrap doesn't crash
     #[test]
     fn date_time_format() {
-        // making sure the unwrap doesn't crash
         super::date_time_format();
     }
 }

--- a/piquel-core/src/logging/logger.rs
+++ b/piquel-core/src/logging/logger.rs
@@ -1,5 +1,5 @@
 use log::{Level, Metadata, Record};
-use time;
+use time::{self, OffsetDateTime};
 
 pub struct Logger {
     enable: bool,
@@ -37,9 +37,32 @@ impl log::Log for Logger {
         if !self.enabled(record.metadata()) {
             return;
         }
+        let now = OffsetDateTime::now_utc();
+        let fmt = time::format_description::parse("[year]/[month]/[day] [hour]:[minute]:[second]")
+            .unwrap();
 
-        println!("{} - {}", record.level(), record.args());
+        let timestamp = now.format(&fmt).unwrap();
+        let log_level = format_log_level(record.level());
+
+        let prefix = if self.date_time {
+            format!("{} {}", timestamp, log_level)
+        } else {
+            log_level
+        };
+
+        let msg = format!("{} {}", prefix, record.args());
+
+        if record.level() == Level::Error {
+            println!("{msg}");
+        } else {
+            eprintln!("{msg}");
+        }
     }
 
     fn flush(&self) {}
+}
+
+fn format_log_level(level: Level) -> String {
+    // TODO: color the string
+    format!("[{}]", level.to_string())
 }

--- a/piquel-core/src/logging/logger.rs
+++ b/piquel-core/src/logging/logger.rs
@@ -9,7 +9,7 @@ pub struct Logger {
 
 impl Logger {
     pub fn new(enable: bool, verbose: bool, prefix: bool) -> Self {
-        let max_level = if verbose { Level::Info } else { Level::Trace };
+        let max_level = if verbose { Level::Trace } else { Level::Info };
         Logger {
             enable,
             max_level,

--- a/piquel-core/src/logging/logger.rs
+++ b/piquel-core/src/logging/logger.rs
@@ -1,4 +1,5 @@
 use log::{Level, Metadata, Record};
+use time;
 
 pub struct Logger {
     enable: bool,

--- a/piquel-core/src/logging/logger.rs
+++ b/piquel-core/src/logging/logger.rs
@@ -35,8 +35,7 @@ impl log::Log for Logger {
         }
 
         let now = OffsetDateTime::now_utc();
-        let fmt = time::format_description::parse("[year]/[month]/[day] [hour]:[minute]:[second]")
-            .unwrap();
+        let fmt = date_time_format();
 
         let timestamp = now.format(&fmt).unwrap();
         let log_level = format_log_level(record.level());
@@ -89,4 +88,17 @@ enum Color {
 
 fn make_colored_message(color: Color, message: &str) -> String {
     format!("\x1b[{}m{}\x1b[0m", color as usize, message)
+}
+
+fn date_time_format() -> Vec<time::format_description::BorrowedFormatItem<'static>> {
+    time::format_description::parse("[year]/[month]/[day] [hour]:[minute]:[second]").unwrap()
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn date_time_format() {
+        // making sure the unwrap doesn't crash
+        super::date_time_format();
+    }
 }

--- a/piquel-core/src/logging/logger.rs
+++ b/piquel-core/src/logging/logger.rs
@@ -1,0 +1,44 @@
+use log::{Level, Metadata, Record};
+
+pub struct Logger {
+    enable: bool,
+    max_level: Level,
+    date_time: bool,
+}
+
+pub fn init(logger: Box<Logger>) -> Result<(), Box<dyn std::error::Error>> {
+    let max_level = logger.max_level.to_level_filter();
+    log::set_boxed_logger(logger)?;
+    log::set_max_level(max_level);
+
+    Ok(())
+}
+
+impl Logger {
+    pub fn new(enable: bool, max_level: Level, date_time: bool) -> Self {
+        Logger {
+            enable,
+            max_level,
+            date_time,
+        }
+    }
+}
+
+impl log::Log for Logger {
+    fn enabled(&self, metadata: &Metadata) -> bool {
+        if !self.enable {
+            return false;
+        }
+
+        metadata.level() <= self.max_level
+    }
+    fn log(&self, record: &Record) {
+        if !self.enabled(record.metadata()) {
+            return;
+        }
+
+        println!("{} - {}", record.level(), record.args());
+    }
+
+    fn flush(&self) {}
+}

--- a/piquelctl/Cargo.toml
+++ b/piquelctl/Cargo.toml
@@ -8,3 +8,4 @@ default-run = "piquelctl"
 piquel-core = { path = "../piquel-core/" }
 clap.workspace = true
 serde.workspace = true
+log.workspace = true

--- a/piquelctl/src/cli.rs
+++ b/piquelctl/src/cli.rs
@@ -17,6 +17,8 @@ pub fn parse() -> Cli {
         .required(false)  // neither is required
 ))]
 pub struct Cli {
+    #[arg(short = 'v', long = "verbose", global = true)]
+    pub verbose: bool,
     /// Custom path to configuration
     #[arg(long = "config", value_name = "path", global = true)]
     pub config_path: Option<PathBuf>,

--- a/piquelctl/src/lib.rs
+++ b/piquelctl/src/lib.rs
@@ -1,11 +1,13 @@
 use std::path::PathBuf;
 use std::{io, panic};
 
+use log::info;
 use piquelcore::config::{Config, defaults};
 use piquelcore::ipc::client::Client;
 use piquelcore::ipc::message::{Command, Response};
 
 use cli::Commands;
+use piquelcore::logging::{self, logger::Logger};
 
 use crate::cli::Cli;
 use crate::config::ClientConfig;
@@ -15,6 +17,9 @@ mod config;
 
 pub fn run() -> Result<(), Box<dyn std::error::Error>> {
     let cli = cli::parse();
+
+    let logger = Box::new(Logger::new(true, cli.verbose, false));
+    logging::init(logger)?;
 
     let pwd = match std::env::current_dir() {
         Ok(mut path) => {
@@ -91,7 +96,7 @@ fn create_client(config: &Option<ClientConfig>, cli: &Cli) -> io::Result<Client>
 }
 
 fn handle_response(command: &Command, response: &Response) {
-    println!(
+    info!(
         "{}",
         match response {
             Response::Ok => "Success",

--- a/piquelctl/src/lib.rs
+++ b/piquelctl/src/lib.rs
@@ -95,7 +95,7 @@ fn create_client(config: &Option<ClientConfig>, cli: &Cli) -> io::Result<Client>
     })
 }
 
-fn handle_response(command: &Command, response: &Response) {
+fn handle_response(_command: &Command, response: &Response) {
     info!(
         "{}",
         match response {

--- a/piqueld/Cargo.toml
+++ b/piqueld/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 
 [dependencies]
 piquel-core = { path = "../piquel-core/" }
+log.workspace = true
 clap.workspace = true
 tokio.workspace = true
 serde.workspace = true

--- a/piqueld/src/lib.rs
+++ b/piqueld/src/lib.rs
@@ -5,12 +5,17 @@ use clap::Parser;
 use std::path::PathBuf;
 
 use crate::server::Server;
-use piquelcore::config::{Config, defaults};
+use piquelcore::{
+    config::{Config, defaults},
+    logging::{self, logger::Logger},
+};
 
 #[derive(Parser, Debug)]
 #[command(name = "piquelctl")]
 #[command(about = "CLI for piqueld", long_about = None)]
 pub struct Cli {
+    #[arg(short = 'v', long = "verbose", global = true)]
+    pub verbose: bool,
     /// Custom path to configuration
     #[arg(long = "config",
         value_name = "path",
@@ -23,6 +28,9 @@ pub struct Cli {
 pub async fn run() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
     let config = config::ServerConfig::load(&cli.config_path)?;
+
+    let logger = Box::new(Logger::new(true, cli.verbose, true));
+    logging::init(logger)?;
 
     Ok(Server::new((config.address, config.port), config.socket)
         .listen()

--- a/piqueld/src/server.rs
+++ b/piqueld/src/server.rs
@@ -1,3 +1,4 @@
+use log::info;
 use piquelcore::ipc::message::{Command, Response};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -26,7 +27,7 @@ impl Server {
     async fn listen_tcp(self: Arc<Self>) -> tokio::io::Result<()> {
         let addr = format!("{}:{}", self.address, self.port);
         let listener = TcpListener::bind(&addr).await?;
-        println!("[TCP] Listening on {addr}");
+        info!("[TCP] Listening on {addr}");
         loop {
             let (stream, _) = listener.accept().await?;
             let server = Arc::clone(&self);
@@ -38,7 +39,7 @@ impl Server {
             std::fs::remove_file(&self.uds_path)?;
         }
         let listener = UnixListener::bind(&self.uds_path)?;
-        println!("[UDS] Listening on {:?}", self.uds_path);
+        info!("[UDS] Listening on {:?}", self.uds_path);
         loop {
             let (stream, _) = listener.accept().await?;
             let server = Arc::clone(&self);
@@ -71,11 +72,11 @@ impl Server {
             ),
             Command::Echo(msg) => Response::Message(msg),
             Command::Reload => {
-                println!("Received reload command");
+                info!("Received reload command");
                 Response::Ok
             }
             Command::Stop => {
-                println!("Received stop command");
+                info!("Received stop command");
                 Response::Ok
             }
         })

--- a/piqueld/src/server.rs
+++ b/piqueld/src/server.rs
@@ -70,11 +70,7 @@ impl Server {
         conn_type: ConnectionType,
         command: Command,
     ) -> tokio::io::Result<Response> {
-        let prefix = match conn_type {
-            ConnectionType::Tcp => "[TCP]",
-            ConnectionType::Uds => "[UDS]",
-        };
-        info!("{prefix} Received Command: {command:#}");
+        info!("[{conn_type}] Received Command: {command:#}");
 
         Ok(match command {
             Command::Status => Response::Message("Status OK".to_string()),

--- a/piqueld/src/server.rs
+++ b/piqueld/src/server.rs
@@ -1,4 +1,5 @@
 use log::info;
+use piquelcore::ipc::ConnectionType;
 use piquelcore::ipc::message::{Command, Response};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -31,7 +32,7 @@ impl Server {
         loop {
             let (stream, _) = listener.accept().await?;
             let server = Arc::clone(&self);
-            tokio::spawn(async move { server.handle(stream).await });
+            tokio::spawn(async move { server.handle(ConnectionType::Tcp, stream).await });
         }
     }
     async fn listen_uds(self: Arc<Self>) -> tokio::io::Result<()> {
@@ -43,10 +44,10 @@ impl Server {
         loop {
             let (stream, _) = listener.accept().await?;
             let server = Arc::clone(&self);
-            tokio::spawn(async move { server.handle(stream).await });
+            tokio::spawn(async move { server.handle(ConnectionType::Uds, stream).await });
         }
     }
-    async fn handle<T>(&self, mut stream: T) -> tokio::io::Result<()>
+    async fn handle<T>(&self, conn_type: ConnectionType, mut stream: T) -> tokio::io::Result<()>
     where
         T: AsyncRead + AsyncWrite + Unpin,
     {
@@ -57,14 +58,24 @@ impl Server {
             let mut cmd_buf = vec![0u8; len];
             stream.read_exact(&mut cmd_buf).await?;
             let command: Command = serde_json::from_slice(&cmd_buf)?;
-            let response = self.process_command(command)?;
+            let response = self.process_command(conn_type, command)?;
             let response_data = serde_json::to_vec(&response)?;
             let len = (response_data.len() as u32).to_be_bytes();
             stream.write_all(&len).await?;
             stream.write_all(&response_data).await?;
         }
     }
-    fn process_command(&self, command: Command) -> tokio::io::Result<Response> {
+    fn process_command(
+        &self,
+        conn_type: ConnectionType,
+        command: Command,
+    ) -> tokio::io::Result<Response> {
+        let prefix = match conn_type {
+            ConnectionType::Tcp => "[TCP]",
+            ConnectionType::Uds => "[UDS]",
+        };
+        info!("{prefix} Received Command: {command:#}");
+
         Ok(match command {
             Command::Status => Response::Message("Status OK".to_string()),
             Command::Hostname => Response::Message(


### PR DESCRIPTION
Add logging with the `log` crate.

## Changes

- Add `log` & `time` crates.
- Create `Logger` implementation with options to display log level & data, as well as verbosity configuration.
- Implement `std::fmt::Display` for `Command` & `ConnectionType`
- Add verbosity flag to Daemon & Client
- Update all logging to use `log` crate.
- Refactor `Client` creation for logging.

## TODO

- [x] Add color to log level output