### PR TITLE
add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: Build & Test
+
+on:
+  push:
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        toolchain:
+          - stable
+          - beta
+          - nightly
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup
+      run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --verbose
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,17 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - 'nix/**'
+      - 'flake.nix'
+      - 'flake.lock'
+      - 'README.md'
   pull_request:
+    paths-ignore:
+      - 'nix/**'
+      - 'flake.nix'
+      - 'flake.lock'
+      - 'README.md'
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: Build & Test
 
 on:
   push:
+    branches:
+      - main
   pull_request:
 
 env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,4 +36,14 @@ jobs:
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
+    - name: Upload piqueld
+      uses: actions/upload-artifact@v4
+      with:
+        name: piqueld-${{ matrix.toolchain }}
+        path: target/debug/piqueld
+    - name: Upload piquelctl
+      uses: actions/upload-artifact@v4
+      with:
+        name: piquelctl-${{ matrix.toolchain }}
+        path: target/debug/piquelctl
 


### PR DESCRIPTION
Add CI workflow to build & test. Runs on `stable`, `beta` and `nightly` rustup toolchains. Artifacts are exported.