### PR TITLE
chore: add t3 project configuration

### DIFF
--- a/t3.json
+++ b/t3.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://t3.codes/schema/t3.json",
+  "scripts": [
+    {
+      "name": "Setup Worktree",
+      "command": "cargo build --workspace --locked",
+      "icon": "configure",
+      "runOnWorktreeCreate": true
+    },
+    {
+      "name": "Run Control Plane",
+      "command": "cargo run --package piqueld",
+      "icon": "play"
+    },
+    {
+      "name": "Check Workspace",
+      "command": "cargo check --workspace --all-targets",
+      "icon": "build"
+    },
+    {
+      "name": "Format Workspace",
+      "command": "cargo fmt --all",
+      "icon": "configure"
+    },
+    {
+      "name": "Lint Workspace",
+      "command": "cargo clippy --workspace --all-targets",
+      "icon": "lint"
+    },
+    {
+      "name": "Audit Dependencies",
+      "command": "cargo deny check",
+      "icon": "lint"
+    },
+    {
+      "name": "Test Workspace",
+      "command": "cargo nextest run --workspace",
+      "icon": "test"
+    },
+    {
+      "name": "Validate Workspace",
+      "command": "just",
+      "icon": "test"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Add a project-level `t3.json` with useful worktree setup, daemon launch, workspace checks, formatting, linting, dependency auditing, tests, and the canonical `just` validation command.

## Validation

- `just` (passes; 110 tests and doc-tests)

Generated by GPT-5.6 via T3 Code.
